### PR TITLE
Fix query params being percent-encoded in API requests

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -119,10 +119,22 @@ func (e ErrorResponse) Error() string {
 
 // makeRequest performs an HTTP request to the API
 func (c *Client) makeRequest(ctx context.Context, method, path string, body interface{}) (*http.Response, error) {
+	// Separate path from query string before joining, since url.JoinPath
+	// percent-encodes '?' when it appears in path segments
+	pathPart := path
+	queryPart := ""
+	if idx := strings.Index(path, "?"); idx != -1 {
+		pathPart = path[:idx]
+		queryPart = path[idx+1:]
+	}
+
 	// Construct URL
-	u, err := url.JoinPath(c.baseURL, path)
+	u, err := url.JoinPath(c.baseURL, pathPart)
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct URL: %w", err)
+	}
+	if queryPart != "" {
+		u = u + "?" + queryPart
 	}
 
 	// Prepare request body

--- a/pkg/client/toneclone_test.go
+++ b/pkg/client/toneclone_test.go
@@ -126,6 +126,28 @@ func TestValidateConnectionFailure(t *testing.T) {
 	}
 }
 
+func TestQueryParamsPreserved(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/style-guard/bundle/preview" {
+			t.Errorf("Expected path /style-guard/bundle/preview, got %s", r.URL.Path)
+		}
+		if r.URL.Query().Get("bundleType") != "comprehensive" {
+			t.Errorf("Expected query param bundleType=comprehensive, got %s", r.URL.Query().Get("bundleType"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	client := NewToneCloneClient("test_key", WithBaseURL(server.URL))
+
+	_, err := client.StyleGuard.BundlePreview(context.Background(), "comprehensive")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+}
+
 func TestPing(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/ping" {


### PR DESCRIPTION
## Summary
- `url.JoinPath` percent-encodes `?` when it appears in path segments, so query parameters (e.g. `?bundleType=comprehensive`) were sent as literal path characters causing 404s
- Fixes bundle preview, bundle status, and bundle remove endpoints
- Adds regression test for query param preservation

## Test plan
- [x] `go test ./...` passes
- [x] `TestQueryParamsPreserved` validates query params reach the server correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)