### PR TITLE
Fix bundle preview and status response types

### DIFF
--- a/cmd/style_guard.go
+++ b/cmd/style_guard.go
@@ -385,7 +385,7 @@ func runBundlePreview(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	items, err := apiClient.StyleGuard.BundlePreview(ctx, sgBundleType)
+	response, err := apiClient.StyleGuard.BundlePreview(ctx, sgBundleType)
 	if err != nil {
 		return err
 	}
@@ -393,24 +393,22 @@ func runBundlePreview(cmd *cobra.Command, args []string) error {
 	if sgFormat == "json" {
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")
-		return encoder.Encode(map[string]interface{}{
-			"bundleType": sgBundleType,
-			"items":      items,
-			"count":      len(items),
-		})
+		return encoder.Encode(response)
 	}
 
-	if len(items) == 0 {
+	if len(response.Items) == 0 {
 		fmt.Println("No items in bundle.")
 		return nil
 	}
+
+	fmt.Printf("Bundle: %s (v%s)\n\n", response.Type, response.Version)
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	defer w.Flush()
 
 	fmt.Fprintf(w, "WORD\tMODE\tREPLACEMENT\tCATEGORY\n")
 	fmt.Fprintf(w, "----\t----\t-----------\t--------\n")
-	for _, item := range items {
+	for _, item := range response.Items {
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\n",
 			item.Word,
 			item.Mode,
@@ -453,9 +451,10 @@ func runBundleStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Bundle Status\n")
 	fmt.Printf("=============\n")
 	fmt.Printf("Applied:        %t\n", status.Applied)
-	fmt.Printf("Bundle Type:    %s\n", status.BundleType)
-	fmt.Printf("Bundle Version: %s\n", status.BundleVersion)
-	fmt.Printf("Word Count:     %d\n", status.WordCount)
+	fmt.Printf("Bundle Type:    %s\n", status.Type)
+	fmt.Printf("Bundle Version: %s\n", status.Version)
+	fmt.Printf("Total Words:    %d\n", status.WordsCount)
+	fmt.Printf("Active Words:   %d\n", status.ActiveCount)
 
 	return nil
 }

--- a/pkg/client/style_guard.go
+++ b/pkg/client/style_guard.go
@@ -41,16 +41,24 @@ type ApplyBundleRequest struct {
 type BundlePreviewItem struct {
 	Word              string `json:"word"`
 	Mode              string `json:"mode"`
-	CustomReplacement string `json:"customReplacement,omitempty"`
+	CustomReplacement string `json:"replacement,omitempty"`
 	Category          string `json:"category,omitempty"`
+}
+
+// BundlePreviewResponse represents the API response for bundle preview
+type BundlePreviewResponse struct {
+	Version string              `json:"version"`
+	Type    string              `json:"type"`
+	Items   []BundlePreviewItem `json:"items"`
 }
 
 // BundleStatusResponse represents the status of a bundle application
 type BundleStatusResponse struct {
-	Applied       bool   `json:"applied"`
-	BundleType    string `json:"bundleType,omitempty"`
-	BundleVersion string `json:"bundleVersion,omitempty"`
-	WordCount     int    `json:"wordCount"`
+	Applied     bool   `json:"applied"`
+	Version     string `json:"version,omitempty"`
+	Type        string `json:"type,omitempty"`
+	WordsCount  int    `json:"wordsCount"`
+	ActiveCount int    `json:"activeCount"`
 }
 
 // List retrieves all global style guard rules
@@ -103,17 +111,17 @@ func (s *StyleGuardClient) Delete(ctx context.Context, styleGuardID string) erro
 }
 
 // BundlePreview previews items in a style guard bundle
-func (s *StyleGuardClient) BundlePreview(ctx context.Context, bundleType string) ([]BundlePreviewItem, error) {
-	var items []BundlePreviewItem
+func (s *StyleGuardClient) BundlePreview(ctx context.Context, bundleType string) (*BundlePreviewResponse, error) {
+	var response BundlePreviewResponse
 	path := "/style-guard/bundle/preview"
 	if bundleType != "" {
 		path = fmt.Sprintf("%s?bundleType=%s", path, url.QueryEscape(bundleType))
 	}
-	err := s.client.Get(ctx, path, &items)
+	err := s.client.Get(ctx, path, &response)
 	if err != nil {
 		return nil, fmt.Errorf("failed to preview bundle: %w", err)
 	}
-	return items, nil
+	return &response, nil
 }
 
 // BundleStatus retrieves the bundle application status

--- a/pkg/client/toneclone_test.go
+++ b/pkg/client/toneclone_test.go
@@ -136,15 +136,24 @@ func TestQueryParamsPreserved(t *testing.T) {
 		}
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`[]`))
+		w.Write([]byte(`{"version":"2.0.0","type":"comprehensive","items":[{"word":"delve into","replacement":"explore","mode":"CUSTOM","category":"phrase"}]}`))
 	}))
 	defer server.Close()
 
 	client := NewToneCloneClient("test_key", WithBaseURL(server.URL))
 
-	_, err := client.StyleGuard.BundlePreview(context.Background(), "comprehensive")
+	resp, err := client.StyleGuard.BundlePreview(context.Background(), "comprehensive")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
+	}
+	if resp.Version != "2.0.0" {
+		t.Errorf("Expected version 2.0.0, got %s", resp.Version)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("Expected 1 item, got %d", len(resp.Items))
+	}
+	if resp.Items[0].Word != "delve into" {
+		t.Errorf("Expected word 'delve into', got %s", resp.Items[0].Word)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bundle preview API returns `{version, type, items}` not a bare array — added `BundlePreviewResponse` wrapper
- Bundle preview items use `replacement` field, not `customReplacement` — fixed JSON tag
- Bundle status API returns `{applied, version, type, wordsCount, activeCount}` — fixed all field names in `BundleStatusResponse`

## Test plan
- [x] `go test ./...` passes
- [x] All commands verified against live API (list, add, update, delete, bundle preview/status, typos get/set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)