### PR TITLE
Write prime output to stdout

### DIFF
--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -141,10 +140,10 @@ Examples:
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(os.Stdout, out)
+			fmt.Fprintln(cmd.OutOrStdout(), out)
 			return nil
 		}
-		fmt.Fprint(os.Stdout, primeText(g))
+		fmt.Fprint(cmd.OutOrStdout(), primeText(g))
 		return nil
 	},
 }

--- a/cmd/prime.go
+++ b/cmd/prime.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -140,10 +141,10 @@ Examples:
 			if err != nil {
 				return err
 			}
-			cmd.Println(out)
+			fmt.Fprintln(os.Stdout, out)
 			return nil
 		}
-		cmd.Print(primeText(g))
+		fmt.Fprint(os.Stdout, primeText(g))
 		return nil
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,6 +96,12 @@ func writeOutputAliasRequestsJSON(args []string) bool {
 func init() {
 	cobra.OnInitialize(initConfig)
 
+	// Cobra defaults successful command output to stderr unless an output writer
+	// is configured. Keep successful, pipeable output on stdout while errors and
+	// diagnostics continue to use stderr.
+	rootCmd.SetOut(os.Stdout)
+	rootCmd.SetErr(os.Stderr)
+
 	// Global flags
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.toneclone.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "verbose output")

--- a/test/prime_cli_test.go
+++ b/test/prime_cli_test.go
@@ -1,0 +1,36 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"os/exec"
+	"testing"
+)
+
+func TestPrimeJSONWritesMachineOutputToStdout(t *testing.T) {
+	cmd := exec.Command("go", "run", "..", "prime", "--json")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("toneclone prime --json failed: %v\nstderr: %s", err, stderr.String())
+	}
+	if stdout.Len() == 0 {
+		t.Fatalf("expected JSON on stdout; stderr contained: %s", stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected quiet stderr, got: %s", stderr.String())
+	}
+
+	var output struct {
+		Product string `json:"product"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+		t.Fatalf("stdout was not valid JSON: %v\nstdout: %s", err, stdout.String())
+	}
+	if output.Product != "ToneClone CLI" {
+		t.Fatalf("unexpected product: %q", output.Product)
+	}
+}

--- a/test/prime_cli_test.go
+++ b/test/prime_cli_test.go
@@ -7,30 +7,46 @@ import (
 	"testing"
 )
 
-func TestPrimeJSONWritesMachineOutputToStdout(t *testing.T) {
-	cmd := exec.Command("go", "run", "..", "prime", "--json")
-	var stdout bytes.Buffer
-	var stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("toneclone prime --json failed: %v\nstderr: %s", err, stderr.String())
-	}
-	if stdout.Len() == 0 {
-		t.Fatalf("expected JSON on stdout; stderr contained: %s", stderr.String())
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("expected quiet stderr, got: %s", stderr.String())
+func TestPrimeWritesSuccessOutputToStdout(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		json bool
+	}{
+		{name: "text", args: []string{"prime"}},
+		{name: "json", args: []string{"prime", "--json"}, json: true},
 	}
 
-	var output struct {
-		Product string `json:"product"`
-	}
-	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
-		t.Fatalf("stdout was not valid JSON: %v\nstdout: %s", err, stdout.String())
-	}
-	if output.Product != "ToneClone CLI" {
-		t.Fatalf("unexpected product: %q", output.Product)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("go", append([]string{"run", ".."}, tt.args...)...)
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("toneclone %v failed: %v\nstderr: %s", tt.args, err, stderr.String())
+			}
+			if stdout.Len() == 0 {
+				t.Fatalf("expected output on stdout; stderr contained: %s", stderr.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("expected quiet stderr, got: %s", stderr.String())
+			}
+			if !tt.json {
+				return
+			}
+
+			var output struct {
+				Product string `json:"product"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
+				t.Fatalf("stdout was not valid JSON: %v\nstdout: %s", err, stdout.String())
+			}
+			if output.Product != "ToneClone CLI" {
+				t.Fatalf("unexpected product: %q", output.Product)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- write `toneclone prime` text and JSON output to stdout
- keep stderr quiet on successful prime execution
- add a command-level regression test that runs the CLI and validates JSON stdout

## Why
Pre-release validation for v1.2.0 found `toneclone prime --json` emitted its machine-readable document on stderr, leaving stdout empty and breaking agent pipelines.

## Verification
- `go test ./...`
- `go vet ./...`
- built binary: `prime --json` parsed successfully from stdout with empty stderr