### PR TITLE
Fix directory training uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ toneclone training add --text="Sample content" --filename="sample.txt" --persona
 # Upload file
 toneclone training add --file="document.pdf" --persona="Professional"
 
-# Bulk upload directory
+# Upload a directory, preserving each file as a separate writing sample
 toneclone training add --directory="./docs" --recursive --persona="Technical"
 
 # Associate file with persona
@@ -345,6 +345,7 @@ toneclone knowledge create \
 ```bash
 # Upload training materials
 toneclone training add --file="brand-guidelines.pdf" --persona="Marketing"
+# Directory uploads preserve each file as a separate writing sample.
 toneclone training add --directory="./docs" --recursive --persona="Technical"
 
 # Manage file associations

--- a/cmd/training.go
+++ b/cmd/training.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -70,7 +69,8 @@ var addTrainingCmd = &cobra.Command{
 	Long: `Add training data by uploading files or text content.
 
 Files can be uploaded from local filesystem or text can be provided directly.
-Files are automatically associated with the specified persona.
+Directory uploads preserve each file as a separate writing sample, then associate
+all successful uploads with the specified persona in one operation.
 
 Examples:
   toneclone training add --file=document.txt --persona=professional
@@ -428,7 +428,6 @@ func runDisassociateTraining(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-
 // Helper functions
 
 func addTextTraining(ctx context.Context, apiClient *client.ToneCloneClient, persona *client.Persona) error {
@@ -558,97 +557,59 @@ func addDirectoryTraining(ctx context.Context, apiClient *client.ToneCloneClient
 	}
 
 	fmt.Printf("Found %d files to upload\n", len(files))
+	return uploadDirectoryFiles(ctx, apiClient, persona, files, trainingVerbose)
+}
 
-	// Process files in batches for better efficiency
-	const batchSize = 10
-	var totalUploaded int
-	var totalAssociated int
-
-	for i := 0; i < len(files); i += batchSize {
-		end := i + batchSize
-		if end > len(files) {
-			end = len(files)
+func uploadDirectoryFiles(ctx context.Context, apiClient *client.ToneCloneClient, persona *client.Persona, files []string, verbose bool) error {
+	fileIDs := make([]string, 0, len(files))
+	failures := make([]string, 0)
+	for i, filePath := range files {
+		filename := filepath.Base(filePath)
+		if verbose {
+			fmt.Printf("Uploading file %d/%d: %s\n", i+1, len(files), filename)
 		}
 
-		batch := files[i:end]
-		batchNum := (i / batchSize) + 1
-		totalBatches := (len(files) + batchSize - 1) / batchSize
-
-		if trainingVerbose {
-			fmt.Printf("Processing batch %d/%d (%d files)\n", batchNum, totalBatches, len(batch))
-		}
-
-		// Prepare file uploads for this batch
-		var fileUploads []client.FileUpload
-
-		for _, filePath := range batch {
-			filename := filepath.Base(filePath)
-			
-			// Open file
-			file, err := os.Open(filePath)
-			if err != nil {
-				fmt.Printf("  ✗ Failed to open %s: %v\n", filename, err)
-				continue
-			}
-
-			fileUploads = append(fileUploads, client.FileUpload{
-				Filename: filename,
-				Reader:   file,
-			})
-		}
-
-		// Skip if no valid files in this batch
-		if len(fileUploads) == 0 {
-			continue
-		}
-
-		// Get persona ID for batch upload
-		var personaID string
-		if persona != nil {
-			personaID = persona.PersonaID
-		}
-
-		// Upload batch with integrated persona association
-		response, err := apiClient.Training.UploadFileBatch(ctx, fileUploads, personaID, "cli")
-		
-		// Close all files
-		for _, upload := range fileUploads {
-			if closer, ok := upload.Reader.(io.Closer); ok {
-				closer.Close()
-			}
-		}
-
+		file, err := os.Open(filePath)
 		if err != nil {
-			fmt.Printf("  ✗ Batch upload failed: %v\n", err)
+			fmt.Printf("  ✗ %s failed: %v\n", filename, err)
+			failures = append(failures, filePath)
 			continue
 		}
-
-		// Report results for this batch
-		for _, result := range response.Files {
-			if result.Status == "success" {
-				fmt.Printf("  ✓ %s uploaded", result.Filename)
-				if result.FileID != "" {
-					fmt.Printf(" (ID: %s)", result.FileID)
-				}
-				if result.Associated {
-					fmt.Printf(" and associated with persona")
-				}
-				fmt.Printf("\n")
-			} else {
-				fmt.Printf("  ✗ %s failed: %s\n", result.Filename, result.Error)
-			}
+		uploaded, uploadErr := apiClient.Training.UploadFile(ctx, file, filename)
+		closeErr := file.Close()
+		if uploadErr != nil {
+			fmt.Printf("  ✗ %s failed: %v\n", filename, uploadErr)
+			failures = append(failures, filePath)
+			continue
+		}
+		if closeErr != nil {
+			fmt.Printf("  ! %s uploaded but the local file did not close cleanly: %v\n", filename, closeErr)
 		}
 
-		totalUploaded += response.Summary.Uploaded
-		totalAssociated += response.Summary.Associated
+		fileIDs = append(fileIDs, uploaded.FileID)
+		fmt.Printf("  ✓ %s uploaded (ID: %s)\n", filename, uploaded.FileID)
 	}
 
-	fmt.Printf("✓ %d files uploaded successfully", totalUploaded)
-	if persona != nil && totalAssociated > 0 {
-		fmt.Printf(", %d associated with persona '%s'", totalAssociated, persona.Name)
+	if persona != nil && len(fileIDs) > 0 {
+		if err := apiClient.Personas.AssociateFiles(ctx, persona.PersonaID, fileIDs); err != nil {
+			recoveryCommand := fmt.Sprintf(
+				"toneclone training associate --file-id=%q --persona=%q",
+				strings.Join(fileIDs, ","),
+				persona.PersonaID,
+			)
+			return fmt.Errorf(
+				"uploaded %d files, but association with persona %q failed; files remain uploaded but may be unassociated; retry association without re-uploading them:\n%s\noriginal error: %w",
+				len(fileIDs), persona.Name, recoveryCommand, err,
+			)
+		}
+		fmt.Printf("✓ %d files uploaded and associated with persona '%s'\n", len(fileIDs), persona.Name)
+	} else {
+		fmt.Printf("✓ %d files uploaded successfully\n", len(fileIDs))
 	}
-	fmt.Printf("\n")
 
+	if len(failures) > 0 {
+		return fmt.Errorf("%d of %d files failed to upload: %s", len(failures), len(files), strings.Join(failures, ", "))
+	}
 	return nil
 }
 

--- a/cmd/training_directory_test.go
+++ b/cmd/training_directory_test.go
@@ -1,0 +1,173 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/toneclone/cli/pkg/client"
+)
+
+func TestUploadDirectoryFilesProvidesRecoveryCommandWhenAssociationFails(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		writeTrainingTestFile(t, dir, "first.txt", "first sample"),
+		writeTrainingTestFile(t, dir, "second.txt", "second sample"),
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/files":
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("FormFile(file) error = %v", err)
+			}
+			file.Close()
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(client.TrainingFile{FileID: "id-" + header.Filename, FileName: header.Filename})
+		case r.Method == http.MethodPost && r.URL.Path == "/personas/persona-1/files":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":"temporarily unavailable"}`))
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	api := client.NewToneCloneClient("test-key", client.WithBaseURL(server.URL))
+	persona := &client.Persona{PersonaID: "persona-1", Name: "Writer"}
+	err := uploadDirectoryFiles(context.Background(), api, persona, files, false)
+	if err == nil {
+		t.Fatal("uploadDirectoryFiles() error = nil, want association failure")
+	}
+	for _, want := range []string{
+		"files remain uploaded but may be unassociated",
+		"toneclone training associate",
+		"id-first.txt,id-second.txt",
+		"persona-1",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %q, want recovery detail %q", err, want)
+		}
+	}
+}
+
+func TestUploadDirectoryFilesReturnsErrorAfterAssociatingSuccessfulUploads(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		writeTrainingTestFile(t, dir, "first.txt", "first sample"),
+		writeTrainingTestFile(t, dir, "broken.txt", "broken sample"),
+		writeTrainingTestFile(t, dir, "third.txt", "third sample"),
+	}
+
+	var uploadedNames []string
+	var associatedIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/files":
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("FormFile(file) error = %v", err)
+			}
+			file.Close()
+			uploadedNames = append(uploadedNames, header.Filename)
+			w.Header().Set("Content-Type", "application/json")
+			if header.Filename == "broken.txt" {
+				w.WriteHeader(http.StatusBadRequest)
+				w.Write([]byte(`{"error":"invalid sample"}`))
+				return
+			}
+			json.NewEncoder(w).Encode(client.TrainingFile{FileID: "id-" + header.Filename, FileName: header.Filename})
+		case r.Method == http.MethodPost && r.URL.Path == "/personas/persona-1/files":
+			var request struct {
+				FileIDs []string `json:"fileIds"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode association request: %v", err)
+			}
+			associatedIDs = request.FileIDs
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "not found", http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	api := client.NewToneCloneClient("test-key", client.WithBaseURL(server.URL))
+	persona := &client.Persona{PersonaID: "persona-1", Name: "Writer"}
+	err := uploadDirectoryFiles(context.Background(), api, persona, files, false)
+	if err == nil || !strings.Contains(err.Error(), "1 of 3 files failed") {
+		t.Fatalf("uploadDirectoryFiles() error = %v, want partial failure", err)
+	}
+	if got, want := fmt.Sprint(uploadedNames), "[first.txt broken.txt third.txt]"; got != want {
+		t.Fatalf("attempted uploads = %s, want %s", got, want)
+	}
+	if got, want := fmt.Sprint(associatedIDs), "[id-first.txt id-third.txt]"; got != want {
+		t.Fatalf("associated IDs = %s, want %s", got, want)
+	}
+}
+
+func TestUploadDirectoryFilesPreservesEachFileAsASeparateSample(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		writeTrainingTestFile(t, dir, "first.txt", "first sample"),
+		writeTrainingTestFile(t, dir, "second.txt", "second sample"),
+	}
+
+	var uploadedNames []string
+	var associatedIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/files":
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Fatalf("FormFile(file) error = %v", err)
+			}
+			file.Close()
+			uploadedNames = append(uploadedNames, header.Filename)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(client.TrainingFile{FileID: "id-" + header.Filename, FileName: header.Filename})
+		case r.Method == http.MethodPost && r.URL.Path == "/personas/persona-1/files":
+			var request struct {
+				FileIDs []string `json:"fileIds"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode association request: %v", err)
+			}
+			associatedIDs = request.FileIDs
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	api := client.NewToneCloneClient("test-key", client.WithBaseURL(server.URL))
+	persona := &client.Persona{PersonaID: "persona-1", Name: "Writer"}
+	if err := uploadDirectoryFiles(context.Background(), api, persona, files, false); err != nil {
+		t.Fatalf("uploadDirectoryFiles() error = %v", err)
+	}
+
+	if got, want := fmt.Sprint(uploadedNames), "[first.txt second.txt]"; got != want {
+		t.Fatalf("uploaded files = %s, want %s", got, want)
+	}
+	if got, want := fmt.Sprint(associatedIDs), "[id-first.txt id-second.txt]"; got != want {
+		t.Fatalf("associated IDs = %s, want %s", got, want)
+	}
+}
+
+func writeTrainingTestFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/pkg/client/training.go
+++ b/pkg/client/training.go
@@ -85,169 +85,21 @@ func (t *TrainingClient) UploadFile(ctx context.Context, file io.Reader, filenam
 		return nil, fmt.Errorf("failed to copy file content: %w", err)
 	}
 
+	if err := writer.WriteField("source", "cli"); err != nil {
+		return nil, fmt.Errorf("failed to add source field: %w", err)
+	}
+
 	// Close the multipart writer
 	err = writer.Close()
 	if err != nil {
 		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
 	}
 
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "POST", t.client.baseURL+"/files", &body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Authorization", "Bearer "+t.client.apiKey)
-	req.Header.Set("User-Agent", "ToneClone-CLI/1.0")
-
-	// Make request
-	resp, err := t.client.httpClient.Do(req)
-	if err != nil {
+	var uploadedFile TrainingFile
+	if err := t.client.PostMultipart(ctx, "/files", writer.FormDataContentType(), body.Bytes(), &uploadedFile); err != nil {
 		return nil, fmt.Errorf("failed to upload file: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("upload failed with status %d", resp.StatusCode)
-	}
-
-	// Parse response
-	var uploadedFile TrainingFile
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	err = json.Unmarshal(respBody, &uploadedFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
 	return &uploadedFile, nil
-}
-
-// FileUpload represents a file to be uploaded
-type FileUpload struct {
-	Filename string
-	Reader   io.Reader
-}
-
-// BatchFileResult represents the result of uploading a single file in a batch
-type BatchFileResult struct {
-	FileID     string `json:"file_id,omitempty"`
-	Filename   string `json:"filename"`
-	Status     string `json:"status"`
-	Error      string `json:"error,omitempty"`
-	Size       int64  `json:"size,omitempty"`
-	Associated bool   `json:"associated"`
-}
-
-// BatchUploadResponse represents the response from batch file upload
-type BatchUploadResponse struct {
-	Files     []BatchFileResult `json:"files"`
-	PersonaID string           `json:"persona_id,omitempty"`
-	Summary   struct {
-		Total      int `json:"total"`
-		Uploaded   int `json:"uploaded"`
-		Associated int `json:"associated"`
-		Failed     int `json:"failed"`
-	} `json:"summary"`
-}
-
-// UploadFileBatch uploads multiple files in a single request
-func (t *TrainingClient) UploadFileBatch(ctx context.Context, files []FileUpload, personaID, source string) (*BatchUploadResponse, error) {
-	// Create a buffer to hold the multipart form data
-	var body bytes.Buffer
-	writer := multipart.NewWriter(&body)
-
-	// Add files to form
-	for _, file := range files {
-		fileWriter, err := writer.CreateFormFile("files", file.Filename)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create form file for %s: %w", file.Filename, err)
-		}
-
-		// Reset reader if it's seekable
-		if seeker, ok := file.Reader.(io.Seeker); ok {
-			seeker.Seek(0, io.SeekStart)
-		}
-
-		_, err = io.Copy(fileWriter, file.Reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy file content for %s: %w", file.Filename, err)
-		}
-	}
-
-	// Add persona_id if provided
-	if personaID != "" {
-		err := writer.WriteField("persona_id", personaID)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add persona_id field: %w", err)
-		}
-	}
-
-	// Add source
-	if source != "" {
-		err := writer.WriteField("source", source)
-		if err != nil {
-			return nil, fmt.Errorf("failed to add source field: %w", err)
-		}
-	}
-
-	// Close the multipart writer
-	err := writer.Close()
-	if err != nil {
-		return nil, fmt.Errorf("failed to close multipart writer: %w", err)
-	}
-
-	// Create request
-	req, err := http.NewRequestWithContext(ctx, "POST", t.client.baseURL+"/files/batch", &body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-
-	// Set headers
-	req.Header.Set("Content-Type", writer.FormDataContentType())
-	req.Header.Set("Authorization", "Bearer "+t.client.apiKey)
-	req.Header.Set("User-Agent", "ToneClone-CLI/1.0")
-
-	// Make request
-	resp, err := t.client.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to upload files: %w", err)
-	}
-	defer resp.Body.Close()
-
-	// Read response body first
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusPartialContent {
-		// Try to parse error response for more details
-		var errorResp map[string]interface{}
-		if json.Unmarshal(respBody, &errorResp) == nil {
-			if msg, ok := errorResp["error"].(string); ok {
-				return nil, fmt.Errorf("batch upload failed with status %d: %s", resp.StatusCode, msg)
-			}
-			if msg, ok := errorResp["message"].(string); ok {
-				return nil, fmt.Errorf("batch upload failed with status %d: %s", resp.StatusCode, msg)
-			}
-		}
-		return nil, fmt.Errorf("batch upload failed with status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	// Parse response
-	var batchResponse BatchUploadResponse
-	err = json.Unmarshal(respBody, &batchResponse)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
-	}
-
-	return &batchResponse, nil
 }
 
 // UploadText uploads text content

--- a/pkg/client/training_test.go
+++ b/pkg/client/training_test.go
@@ -1,0 +1,91 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestUploadFileDoesNotRetryServerErrorsWithoutIdempotency(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":"temporarily unavailable"}`))
+	}))
+	defer server.Close()
+
+	api := NewClient("test-key", WithBaseURL(server.URL))
+	_, err := NewTrainingClient(api).UploadFile(context.Background(), strings.NewReader("sample text"), "sample.txt")
+	if err == nil {
+		t.Fatal("UploadFile() error = nil, want server error")
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1 to avoid duplicate file creation", requests)
+	}
+}
+
+func TestUploadFileRetriesRateLimits(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limit exceeded"}`))
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TrainingFile{FileID: "file-after-retry", FileName: "sample.txt"})
+	}))
+	defer server.Close()
+
+	api := NewClient("test-key", WithBaseURL(server.URL))
+	file, err := NewTrainingClient(api).UploadFile(context.Background(), strings.NewReader("sample text"), "sample.txt")
+	if err != nil {
+		t.Fatalf("UploadFile() error = %v", err)
+	}
+	if file.FileID != "file-after-retry" || requests != 2 {
+		t.Fatalf("file = %+v, requests = %d; want successful second request", file, requests)
+	}
+}
+
+func TestUploadFileUsesSupportedSingleFileEndpoint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/files" {
+			t.Fatalf("request = %s %s, want POST /files", r.Method, r.URL.Path)
+		}
+		if err := r.ParseMultipartForm(1 << 20); err != nil {
+			t.Fatalf("ParseMultipartForm() error = %v", err)
+		}
+		if got := r.FormValue("source"); got != "cli" {
+			t.Fatalf("source = %q, want cli", got)
+		}
+		file, header, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("FormFile(file) error = %v", err)
+		}
+		file.Close()
+		if header.Filename != "sample.txt" {
+			t.Fatalf("filename = %q, want sample.txt", header.Filename)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(TrainingFile{FileID: "file-1", FileName: header.Filename})
+	}))
+	defer server.Close()
+
+	api := NewClient("test-key", WithBaseURL(server.URL))
+	file, err := NewTrainingClient(api).UploadFile(context.Background(), strings.NewReader("sample text"), "sample.txt")
+	if err != nil {
+		t.Fatalf("UploadFile() error = %v", err)
+	}
+	if file.FileID != "file-1" {
+		t.Fatalf("FileID = %q, want file-1", file.FileID)
+	}
+}

--- a/test/training_cli_test.go
+++ b/test/training_cli_test.go
@@ -1,0 +1,94 @@
+package test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/toneclone/cli/pkg/client"
+)
+
+func TestTrainingAddDirectoryUsesSupportedUploadFlow(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"email-one.txt": "First writing sample",
+		"email-two.txt": "Second writing sample",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var uploadedNames []string
+	var associatedIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/personas/persona-1":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(client.Persona{PersonaID: "persona-1", Name: "Email v2"})
+		case r.Method == http.MethodPost && r.URL.Path == "/files":
+			file, header, err := r.FormFile("file")
+			if err != nil {
+				t.Errorf("FormFile(file) error = %v", err)
+				http.Error(w, "missing file", http.StatusBadRequest)
+				return
+			}
+			file.Close()
+			if source := r.FormValue("source"); source != "cli" {
+				t.Errorf("source = %q, want cli", source)
+			}
+			uploadedNames = append(uploadedNames, header.Filename)
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(client.TrainingFile{FileID: "id-" + header.Filename, FileName: header.Filename})
+		case r.Method == http.MethodPost && r.URL.Path == "/personas/persona-1/files":
+			var request struct {
+				FileIDs []string `json:"fileIds"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Errorf("decode association request: %v", err)
+				http.Error(w, "invalid request", http.StatusBadRequest)
+				return
+			}
+			associatedIDs = request.FileIDs
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"message":"associated"}`))
+		default:
+			http.Error(w, fmt.Sprintf("unexpected request: %s %s", r.Method, r.URL.Path), http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	cmd := exec.Command("go", "run", "..", "training", "add", "--directory="+dir, "--persona=persona-1")
+	cmd.Env = append(os.Environ(),
+		"HOME="+t.TempDir(),
+		"TONECLONE_API_KEY=test_key",
+		"TONECLONE_BASE_URL="+server.URL,
+	)
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("training add failed: %v\nstdout: %s\nstderr: %s", err, stdout.String(), stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("expected quiet stderr, got: %s", stderr.String())
+	}
+
+	sort.Strings(uploadedNames)
+	sort.Strings(associatedIDs)
+	if got, want := strings.Join(uploadedNames, ","), "email-one.txt,email-two.txt"; got != want {
+		t.Fatalf("uploaded files = %q, want %q", got, want)
+	}
+	if got, want := strings.Join(associatedIDs, ","), "id-email-one.txt,id-email-two.txt"; got != want {
+		t.Fatalf("associated IDs = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- replace the nonexistent `/files/batch` workflow with supported one-file-per-sample uploads to `POST /files`
- associate all successful file IDs with the persona in one request
- retry safe `429` responses, but not ambiguous `5xx` file-creation failures
- return non-zero on partial upload failure and provide an exact recovery command if association fails
- remove the phantom exported batch-upload client API
- document that directory uploads preserve sample boundaries

## Regression
`toneclone training add --directory` previously called an endpoint the backend never implemented, logged 25 batch 404s, printed `0 files uploaded successfully`, and exited zero.

## Verification
- `go test ./...`
- `go vet ./...`
- command-level integration test runs the real CLI against an HTTP test server and confirms two separate `/files` uploads plus one persona association
- focused tests cover partial failures, recovery instructions, 429 retry, and no unsafe 5xx retry