### PR TITLE
Fix training CLI test in CI

### DIFF
--- a/test/training_cli_test.go
+++ b/test/training_cli_test.go
@@ -68,7 +68,6 @@ func TestTrainingAddDirectoryUsesSupportedUploadFlow(t *testing.T) {
 
 	cmd := exec.Command("go", "run", "..", "training", "add", "--directory="+dir, "--persona=persona-1")
 	cmd.Env = append(os.Environ(),
-		"HOME="+t.TempDir(),
 		"TONECLONE_API_KEY=test_key",
 		"TONECLONE_BASE_URL="+server.URL,
 	)


### PR DESCRIPTION
## Summary
- stop overriding `HOME` in the command-level CLI test
- preserve the normal Go module cache so `go run` does not redownload modules into `t.TempDir()` with read-only cache permissions

## Verification
- `go test ./...`
- `go vet ./...`

This fixes the v1.2.1 release workflow failure. The release was not published.